### PR TITLE
Fixed realpath return pointer to allocation allocated by the LibC

### DIFF
--- a/include/wimlib/util.h
+++ b/include/wimlib/util.h
@@ -57,6 +57,9 @@ wimlib_calloc(size_t nmemb, size_t size);
 char *
 wimlib_strdup(const char *str);
 
+char *
+wimlib_realpath (const char *path, char *resolved_path);
+
 #ifdef _WIN32
 wchar_t *
 wimlib_wcsdup(const wchar_t *str);
@@ -76,6 +79,7 @@ memdup(const void *mem, size_t size);
 #define REALLOC		wimlib_realloc
 #define CALLOC		wimlib_calloc
 #define STRDUP		wimlib_strdup
+#define REALPATH    wimlib_realpath
 #define WCSDUP		wimlib_wcsdup
 #define ALIGNED_MALLOC	wimlib_aligned_malloc
 #define ALIGNED_FREE	wimlib_aligned_free

--- a/include/wimlib/util.h
+++ b/include/wimlib/util.h
@@ -58,7 +58,7 @@ char *
 wimlib_strdup(const char *str);
 
 char *
-wimlib_realpath (const char *path, char *resolved_path);
+wimlib_realpath(const char *path, char *resolved_path);
 
 #ifdef _WIN32
 wchar_t *

--- a/include/wimlib/win32.h
+++ b/include/wimlib/win32.h
@@ -38,7 +38,7 @@ int
 fsync(int fd);
 
 tchar *
-realpath(const tchar *path, tchar *resolved_path);
+wimlib_realpath(const tchar *path, tchar *resolved_path);
 
 int
 win32_rename_replacement(const tchar *oldpath, const tchar *newpath);

--- a/src/mount_image.c
+++ b/src/mount_image.c
@@ -2261,7 +2261,7 @@ wimlib_mount_image(WIMStruct *wim, int image, const char *dir,
 	prepare_inodes(&ctx);
 
 	/* Save the absolute path to the mountpoint directory.  */
-	ctx.mountpoint_abspath = realpath(dir, NULL);
+	ctx.mountpoint_abspath = wimlib_realpath(dir, NULL);
 	if (ctx.mountpoint_abspath)
 		ctx.mountpoint_abspath_nchars = strlen(ctx.mountpoint_abspath);
 

--- a/src/unix_apply.c
+++ b/src/unix_apply.c
@@ -921,7 +921,7 @@ unix_extract(struct list_head *dentry_list, struct apply_ctx *_ctx)
 	if ((ctx->common.extract_flags & WIMLIB_EXTRACT_FLAG_RPFIX) &&
 	    ctx->common.required_features.symlink_reparse_points)
 	{
-		ctx->target_abspath = realpath(ctx->common.target, NULL);
+		ctx->target_abspath = wimlib_realpath(ctx->common.target, NULL);
 		if (!ctx->target_abspath) {
 			ret = WIMLIB_ERR_NOMEM;
 			goto out;

--- a/src/util.c
+++ b/src/util.c
@@ -109,6 +109,9 @@ char *
 wimlib_realpath(const char *path, char *resolved_path)
 {
 	char *resolved = realpath(path, resolved_path);
+	if (resolved == NULL)
+		return NULL;
+	
 	if (resolved_path == NULL) {
 		char *reallocated = memdup(resolved, strlen(resolved) + 1);
 		free(resolved);

--- a/src/util.c
+++ b/src/util.c
@@ -105,6 +105,15 @@ wimlib_strdup(const char *str)
 	return memdup(str, strlen(str) + 1);
 }
 
+char *
+wimlib_realpath (const char *name, char *resolved_path)
+{
+	if (resolved_path == NULL)
+		resolved_path = wimlib_malloc(PATH_MAX);
+
+	realpath(name, resolved_path);
+}
+
 #ifdef _WIN32
 wchar_t *
 wimlib_wcsdup(const wchar_t *str)

--- a/src/util.c
+++ b/src/util.c
@@ -106,12 +106,12 @@ wimlib_strdup(const char *str)
 }
 
 char *
-wimlib_realpath (const char *name, char *resolved_path)
+wimlib_realpath(const char *path, char *resolved_path)
 {
 	if (resolved_path == NULL)
 		resolved_path = wimlib_malloc(PATH_MAX);
 
-	return realpath(name, resolved_path);
+	return realpath(path, resolved_path);
 }
 
 #ifdef _WIN32

--- a/src/util.c
+++ b/src/util.c
@@ -111,7 +111,7 @@ wimlib_realpath (const char *name, char *resolved_path)
 	if (resolved_path == NULL)
 		resolved_path = wimlib_malloc(PATH_MAX);
 
-	realpath(name, resolved_path);
+	return realpath(name, resolved_path);
 }
 
 #ifdef _WIN32

--- a/src/util.c
+++ b/src/util.c
@@ -108,10 +108,14 @@ wimlib_strdup(const char *str)
 char *
 wimlib_realpath(const char *path, char *resolved_path)
 {
-	if (resolved_path == NULL)
-		resolved_path = wimlib_malloc(PATH_MAX);
+	char *resolved = realpath(path, resolved_path);
+	if (resolved_path == NULL) {
+		char *reallocated = memdup(resolved, strlen(resolved) + 1);
+		free(resolved);
+		return reallocated;
+	}
 
-	return realpath(path, resolved_path);
+	return resolved;
 }
 
 #ifdef _WIN32

--- a/src/wim.c
+++ b/src/wim.c
@@ -668,7 +668,7 @@ begin_read(WIMStruct *wim, const void *wim_filename_or_fd, int open_flags)
 		 * Warning: in Windows native builds, realpath() calls the
 		 * replacement function in win32_replacements.c.
 		 */
-		wim->filename = realpath(wimfile, NULL);
+		wim->filename = wimlib_realpath(wimfile, NULL);
 		if (!wim->filename) {
 			ERROR_WITH_ERRNO("Failed to get full path to file "
 					 "\"%"TS"\"", wimfile);

--- a/src/win32_common.c
+++ b/src/win32_common.c
@@ -205,7 +205,7 @@ win32_get_drive_path(const wchar_t *file_path, wchar_t drive_path[7])
 {
 	tchar *file_abspath;
 
-	file_abspath = realpath(file_path, NULL);
+	file_abspath = wimlib_realpath(file_path, NULL);
 	if (!file_abspath)
 		return WIMLIB_ERR_NOMEM;
 

--- a/src/win32_replacements.c
+++ b/src/win32_replacements.c
@@ -361,7 +361,7 @@ get_available_memory(void)
  * (resolved_path must be NULL).   Also I highly doubt that GetFullPathName
  * really does the right thing under all circumstances. */
 wchar_t *
-realpath(const wchar_t *path, wchar_t *resolved_path)
+wimlib_realpath(const wchar_t *path, wchar_t *resolved_path)
 {
 	DWORD ret;
 	DWORD err;

--- a/src/win32_vss.c
+++ b/src/win32_vss.c
@@ -437,7 +437,7 @@ vss_create_snapshot(const wchar_t *source, UNICODE_STRING *vss_path_ret,
 	HRESULT res;
 	int ret;
 
-	source_abspath = realpath(source, NULL);
+	source_abspath = wimlib_realpath(source, NULL);
 	if (!source_abspath) {
 		ret = WIMLIB_ERR_NOMEM;
 		goto err;


### PR DESCRIPTION
Wimlib supports setting its own allocation hooks. I tried writing custom allocator, but then I encountered error when it tried to read off-bounds. Found out the allocation comes from `LibC`, to be specific, its a buffer allocated by `realpath` when a parameter for output buffer is specified as `NULL` (which is with `wimlib` in all cases).

So I created a wrapper called `wimlib_realpath`, which in case of the `NULL` parameter, after `realpath` returns reallocates and copies the buffer over with wimlib's allocator hook (`memdup`).

Originally, I allocated a buffer manually, but `PATH_MAX`, at least on my system has a size of one page which I considered too much and rather chose to reallocate.
